### PR TITLE
Corrected makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-LIBS = -lssl
+LIBS = -lcrypto -lssl
 WARNS = -Wall -Wextra -pedantic -Werror -Wno-unused-parameter
 CFLAGS := $(WARNS) $(LIBS) -O3 $(CFLAGS)
 TARGS = tripcode sectrip tripfind secfind tripfind-regex secfind-regex


### PR DESCRIPTION
Fixed compiling on Arch. libssl depends on libcrypto, so we should import that too.
